### PR TITLE
Refresh GitHub profile README for current positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,78 +1,25 @@
-<h1>Hello <img src="https://bestanimations.com/uploads/gifs/726892854earth-spinning-rotating-animation-14.gif" alt="World" width="50px" style="vertical-align: middle;" /></h1>
+# Javier Navarro
 
-![](https://visitor-badge.glitch.me/badge?page_id=jnavarrof.jnavarrof)
-![](https://komarev.com/ghpvc/?username=jnavarrof&label=Profile%20views&color=0e75b6&style=flat)
+Engineering Leader | SRE, Observability, HPC & Cloud Platforms
 
-I'm Javier, a **HPC and Cloud Engineer** passionate about ![DevOps-SRE](https://img.shields.io/badge/DevOps-SRE-black) and automate stuff.
-- 🔭&nbsp;Experience working on HPC and Cloud Computing in large Scientific and Research environments. 
-- 🌱&nbsp;I keep improving in Infrastructure as a Code Best Practices & Patterns.
-- 👨‍💻 &nbsp;Interested in Dos and Don'ts of building high-performance teams and improving collaboration.
-- 💬&nbsp;Ask me about High-Performance/High-Throughput Computing, and Private or Public Cloud.
-<br/>
+Engineering leader with 15+ years across HPC, cloud, SRE, and platform engineering. I build and scale reliability, observability, and compute platforms, and I lead teams delivering infrastructure for demanding scientific and SaaS workloads.
 
-🔗&nbsp;**Connect with me:**
-<p align="left">
-<a href="mailto: javier.navarro.fdez@gmail.com" target="blank"><img align="center" src="https://upload.wikimedia.org/wikipedia/commons/7/7e/Gmail_icon_%282020%29.svg" alt="javier.navarro.fdez@gmail.com" height="20"/></a>
-<a href="https://linkedin.com/in/javiernavarrofdez" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/linked-in-alt.svg" alt="javiernavarrofdez" height="20"/></a>
-<!--
-<a href="https://dev.to/jnavarrof" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/devto.svg" alt="jnavarrof" height="30" width="40" /></a>
--->
-</p>
-<br/>
+## Highlights
 
-🛠️&nbsp;**Languages, Tools and Technology Stack:**
-<p align="left">
-<a href="https://www.linux.org/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/linux/linux-original.svg" alt="linux" width="40" height="40"/> </a>
-<a href="https://aws.amazon.com" target="_blank" rel="noreferrer"><img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/amazonwebservices/amazonwebservices-original-wordmark.svg" alt="aws" height="40"/> </a> 
-<a href="https://cloud.google.com" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/google_cloud/google_cloud-icon.svg" alt="gcp" width="40" height="40"/> </a>
-<a href="#" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/openstack/openstack-icon.svg" alt="openstack" width="40" height="40"/> </a>
-<a href="#" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/ceph/ceph-ar21.svg" alt="ceph" height="40"/> </a>
-<a href="https://kubernetes.io" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/kubernetes/kubernetes-icon.svg" alt="kubernetes" width="40" height="40"/> </a> 
-<a href="#" target="_blank" rel="noreferrer"> <img src="https://github.com/cncf/landscape/blob/master/hosted_logos/nomad.svg" alt="nomad" width="40" height="40"/> </a>
-<a href="#" target="_blank" rel="noreferrer"> <img src="https://github.com/cncf/landscape/blob/master/hosted_logos/consul.svg" alt="consul" width="40" height="40"/> </a>
-<a href="#" target="_blank" rel="noreferrer"> <img src="https://github.com/cncf/landscape/blob/master/hosted_logos/vault.svg" alt="vault" width="40" height="40"/> </a>
-<a href="#" target="_blank" rel="noreferrer"> <img src="https://github.com/cncf/landscape/blob/master/hosted_logos/packer.svg" alt="packer" width="40" height="40"/> </a>
-<a href="#" target="_blank" rel="noreferrer"> <img src="https://github.com/cncf/landscape/blob/master/hosted_logos/terraform.svg" alt="terraform" width="40" height="40"/> </a>
-<a href="https://www.docker.com/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/docker/docker-original-wordmark.svg" alt="docker" width="40" height="40"/> </a>
-<a href="#" target="_blank" rel="noreferrer"> <img src="https://biocorecrg.github.io/ELIXIR_containers_nextflow/images/singularity_logo.svg" alt="singularoty" width="40" height="40"/> </a>
-<a href="https://www.gnu.org/software/bash/" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/gnu_bash/gnu_bash-icon.svg" alt="bash" width="40" height="40"/> </a>
-<a href="#" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/python/python-horizontal.svg" alt="python" height="40"/> </a>
-<a href="https://golang.org" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/go/go-original.svg" alt="go" width="40" height="40"/> </a> 
-<a href="https://git-scm.com/" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/git-scm/git-scm-icon.svg" alt="git" width="40" height="40"/> </a>
-<a href="https://www.jenkins.io" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/jenkins/jenkins-icon.svg" alt="jenkins" width="40" height="40"/> </a> 
-<a href="#" target="_blank" rel="noreferrer"> <img src="https://github.com/devicons/devicon/blob/master/icons/confluence/confluence-original-wordmark.svg" alt="confluence" height="40"/> </a>
-<a href="#" target="_blank" rel="noreferrer"> <img src="https://github.com/devicons/devicon/blob/master/icons/bitbucket/bitbucket-original-wordmark.svg" alt="Bitbucket" height="40"/> </a>
-<a href="#" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/atlassian_jira/atlassian_jira-icon.svg" alt="Jira" height="40"/> </a>
-<!--
-<code><img height="20" src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/javascript/javascript.png"></code>
--->
-</p>
-<br/>
+- Lead observability platforms supporting hundreds of engineers and multi-petabyte telemetry workloads.
+- Drove OpenTelemetry adoption and stronger SLO and incident-management practices across engineering platforms.
+- Led a 25-engineer HPC, storage, and cloud organization supporting research-intensive environments at AstraZeneca.
+- Built and operated large-scale scientific computing and hybrid cloud platforms across SaaS and research organizations.
 
-<!-- TODOL dev.to and medium -->
-<!-- https://jnavarrof.github.io/feed.xml -->
-📕 &nbsp;**Latest Blog Posts:**
-<!-- BLOG-POST-LIST:START -->
-- [First post!](https://jnavarrof.github.io/2018-10-26-first-post/)
-<!-- BLOG-POST-LIST:END -->
-<br/>
+## Focus Areas
 
-<h2 align="center">Github Stats</h2>
-<p align="center">
-<a href="https://github.com/jnavarrof/github-readme-stats">
-  <img align="center" src="https://github-readme-stats.vercel.app/api?username=jnavarrof&count_private=true&show_icons=true&repo=github-readme-stats"  alt="GitHub Stats" />
-</a>
-<a href="https://github.com/jnavarrof/convoychat">
-  <img align="center" src="https://github-readme-stats.vercel.app/api/top-langs/?username=jnavarrof&layout=compact" alt="Top Langs" />
-</a>
-</p>
-<br/>
+- Engineering leadership for platform and reliability teams
+- Observability, telemetry platforms, and operational resilience
+- SRE practices, incident management, and service level objectives
+- HPC, scientific computing, and hybrid cloud infrastructure
 
-<h2 align="center">Github Contribution Graph</h2>
-<p align="center">
-  <img src="https://github.com/jnavarrof/jnavarrof/raw/output/github-contribution-grid-snake.svg" alt="snake"></center>
-</p>
+## Contact
 
----
-
-<h4 align="center">Other – <a href='https://jnavarrof.github.io' target="_blank">jnavarrof.github.io</a><h4>
+- Website: https://jnavarrof.github.io
+- LinkedIn: https://www.linkedin.com/in/javiernavarrofdez/
+- Email: mailto:javier.navarro.fdez@gmail.com


### PR DESCRIPTION
## Summary
- replace the older profile-readme style content with a shorter leadership-focused introduction
- highlight current strengths in observability, SRE, HPC, and platform engineering
- keep contact links simple and remove stale badges, widgets, and blog snippets